### PR TITLE
Make Streamlit app work with python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ In comparison the app using Streamlit looks like this:
 
 Both apps feature the same functionality, however Streamlit seems to be significantly slower than Dash. On the other hand the Streamlit only requires roughly half the lines of code of the Dash app. To make the appearance of the Dash app similar, a style sheet is placed in the `assets` folder.
 
-After installing all required packages you can run the Dash app using `python covid_dash.py` and the Streamlit app using `streamlit run covid_streamlit`.
+After installing all required packages you can run the Dash app using `python covid_dash.py` and the Streamlit app using `streamlit run covid_streamlit.py`.

--- a/covid_streamlit.py
+++ b/covid_streamlit.py
@@ -22,30 +22,31 @@ data = read_data()
 column = st.selectbox('Select column',['total_cases','total_cases_per_million','total_deaths','total_deaths_per_million'])
 countries = st.multiselect('Select countries',data["location"].unique())
 
-country_max_cases = []
-country_cases = pd.DataFrame()
-for country in countries:
-    country_cases = country_cases.append(data[data["location"] == country],ignore_index=True)
-    country_max_cases.append(np.max(data[data["location"] == country][column]))
+if countries:
+    country_max_cases = []
+    country_cases = pd.DataFrame()
+    for country in countries:
+        country_cases = country_cases.append(data[data["location"] == country],ignore_index=True)
+        country_max_cases.append(np.max(data[data["location"] == country][column]))
 
-df_max = pd.DataFrame({
-  'country': countries,
-  column: country_max_cases
-})
+    df_max = pd.DataFrame({
+    'country': countries,
+    column: country_max_cases
+    })
 
-df_max = df_max.set_index('country',drop=True)
+    df_max = df_max.set_index('country',drop=True)
 
-col1, col2 = st.beta_columns(2)
+    col1, col2 = st.beta_columns(2)
 
-with col1:
-    st.bar_chart(df_max)
+    with col1:
+        st.bar_chart(df_max)
 
-chart = alt.Chart(country_cases).mark_line().encode(
-    x=alt.X('date:T', axis=alt.Axis(tickCount=10, grid=False)),
-    y=alt.Y(f'{column}:Q'),
-    color='location:N',
-    #strokeDash='location',
-)
+    chart = alt.Chart(country_cases).mark_line().encode(
+        x=alt.X('date:T', axis=alt.Axis(tickCount=10, grid=False)),
+        y=alt.Y(f'{column}:Q'),
+        color='location:N',
+        #strokeDash='location',
+    )
 
-with col2:
-    st.altair_chart(chart, use_container_width=True)
+    with col2:
+        st.altair_chart(chart, use_container_width=True)

--- a/covid_streamlit.py
+++ b/covid_streamlit.py
@@ -20,7 +20,7 @@ def read_data():
     
 data = read_data()
 column = st.selectbox('Select column',['total_cases','total_cases_per_million','total_deaths','total_deaths_per_million'])
-countries = st.multiselect('Select countries',data["location"].unique())
+countries = st.multiselect('Select countries',list(data["location"].unique()))
 
 if countries:
     country_max_cases = []

--- a/covid_streamlit.py
+++ b/covid_streamlit.py
@@ -41,9 +41,9 @@ with col1:
     st.bar_chart(df_max)
 
 chart = alt.Chart(country_cases).mark_line().encode(
-    x=alt.X('date', axis=alt.Axis(tickCount=10, grid=False)),
-    y=alt.Y(column),
-    color='location',
+    x=alt.X('date:T', axis=alt.Axis(tickCount=10, grid=False)),
+    y=alt.Y(f'{column}:Q'),
+    color='location:N',
     #strokeDash='location',
 )
 


### PR DESCRIPTION
I had to make the following changes to get the Streamlit app working (using streamlit v0.84.0 and python3.8):

 * [448f449](https://github.com/axelfiedler/covid/commit/448f44928f9970959342431edba457d8ec29db59): The correct command to start Streamlit is `streamlit run covid_streamlit.py`, otherwise you get: `Error: Streamlit requires raw Python (.py) files, but the provided file has no extension.`
 * [e55d5d5](https://github.com/axelfiedler/covid/commit/e55d5d5df74e30731aaa20c6d7a871b43b6b2d34): Altair uses pandas to determine which data type to use when plotting the data. For any data not part of a pandas dataframe, such as data from a URL or a column from a transform, you will need to [explicitly specify what type the data is](https://altair-viz.github.io/user_guide/encoding.html#encoding-data-types). Also see [this Stackoverflow answer](https://stackoverflow.com/a/68037411/50065). The error I got was:
 
```
 File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/script_runner.py", line 349, in _run_script
    exec(code, module.__dict__)
  File "/home/jervan/github/covid/covid_streamlit.py", line 51, in <module>
    st.altair_chart(chart, use_container_width=True)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/elements/altair.py", line 219, in altair_chart
    marshall(
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/elements/altair.py", line 324, in marshall
    chart_dict = altair_chart.to_dict()
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/vegalite/v4/api.py", line 373, in to_dict
    dct = super(TopLevelMixin, copy).to_dict(*args, **kwargs)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 325, in to_dict
    result = _todict(
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 60, in _todict
    return {
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 61, in <dictcomp>
    k: _todict(v, validate, context)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 56, in _todict
    return obj.to_dict(validate=validate, context=context)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 325, in to_dict
    result = _todict(
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 60, in _todict
    return {
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 61, in <dictcomp>
    k: _todict(v, validate, context)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/utils/schemapi.py", line 56, in _todict
    return obj.to_dict(validate=validate, context=context)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/altair/vegalite/v4/schema/channels.py", line 40, in to_dict
    raise ValueError("{} encoding field is specified without a type; "
ValueError: location encoding field is specified without a type; the type cannot be inferred because it does not match any column in the data.
```

 * [d68b0c8](https://github.com/axelfiedler/covid/commit/d68b0c8870c36f4bff1c13e0870327f16eac7640): When the app starts, no countries are chosen yet in the dropdown, which threw the error ` UserWarning: I don't know how to infer vegalite type from 'empty'.  Defaulting to nominal.`. Adding an `if` statement prevents this.

* [b0cde44](https://github.com/axelfiedler/covid/commit/b0cde449920181a818cec57905a2041846cefe4d): Although [Streamlit multiselect](https://docs.streamlit.io/en/stable/api.html#streamlit.multiselect) should accept a `numpy.ndarray`, I got the error:

```
Exception in thread ScriptRunner.scriptThread:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/script_runner.py", line 182, in _process_request_queue
    widget_states = self._session_state.as_widget_states()
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/state/session_state.py", line 435, in as_widget_states
    return self._new_widget_state.as_widget_states()
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/state/session_state.py", line 186, in as_widget_states
    states = [
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/state/session_state.py", line 189, in <listcomp>
    if self.get_serialized(widget_id)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/state/session_state.py", line 169, in get_serialized
    serialized = metadata.serializer(item.value)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/elements/multiselect.py", line 138, in serialize_multiselect
    return _check_and_convert_to_indices(options, value)
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/elements/multiselect.py", line 121, in _check_and_convert_to_indices
    return [options.index(value) for value in default_values]
  File "/home/biogeek/dashboard_frameworks/env/lib/python3.8/site-packages/streamlit/elements/multiselect.py", line 121, in <listcomp>
    return [options.index(value) for value in default_values]
AttributeError: 'numpy.ndarray' object has no attribute 'index'
```
Wrapping the `ndarray` in a `list` resolves this.
